### PR TITLE
Fixed SQL insert issue with too long headlines

### DIFF
--- a/src/NewsListener/CronListener.php
+++ b/src/NewsListener/CronListener.php
@@ -75,6 +75,11 @@ class CronListener extends \System
                         } else {
                             $title = substr($post['message'],0);
                         }
+                        
+                        // strip title to fit varchar(255) field in tl_news
+                        if (strlen($title) > 255) {
+                            $title = substr($title, 0, 252) . '...';
+                        }
 
                         if (version_compare(VERSION, '4.5', '<')) {
                             //reject overly long 2 byte sequences, as well as characters above U+10000 and replace with ?


### PR DESCRIPTION
Since the title/headline is simply the first line of the facebook post or even the whole message if there are no line breaks (see: https://github.com/pdir/social-feed-bundle/blob/master/src/NewsListener/CronListener.php#L71), there's a good chance that it will be too long for the headline field varchar(255) in the tl_news table. I stripped this variable and added three dots in that case, to avoid this problem.

`SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'headline'`

![image](https://user-images.githubusercontent.com/6792578/49879180-b5ae1880-fe29-11e8-9d70-b2ba83217c87.png)
