### PR TITLE
avoid non-numeric value exception

### DIFF
--- a/src/NewsListener/CronListener.php
+++ b/src/NewsListener/CronListener.php
@@ -16,7 +16,7 @@ class CronListener extends \System
             $lastImport = $obj->pdir_sf_fb_news_last_import_date;
             $tstamp = time();
             $interval = $tstamp - $lastImport;
-            if( ($interval >= $cron && $cron != "no_cronjob") || ($lastImport == "" && $cron != "no_cronjob") ) {
+            if($interval >= $cron && $cron != "no_cronjob") {
                 echo "Cron ausgeführt<br>";
 
                 $appId = $obj->pdir_sf_fb_app_id;

--- a/src/Resources/contao/dca/tl_social_feed.php
+++ b/src/Resources/contao/dca/tl_social_feed.php
@@ -161,7 +161,7 @@ $GLOBALS['TL_DCA']['tl_social_feed'] = [
             'label' => &$GLOBALS['TL_LANG']['tl_social_feed']['pdir_sf_fb_news_last_import_date'],
             'exclude' => true,
             'inputType' => 'text',
-            'sql' => "varchar(255) NOT NULL default ''",
+            'sql' => "varchar(255) NOT NULL default 0",
             'eval' => array('rgxp' => 'date', 'tl_class' => 'w50')
         ],
 
@@ -169,7 +169,7 @@ $GLOBALS['TL_DCA']['tl_social_feed'] = [
             'label' => &$GLOBALS['TL_LANG']['tl_social_feed']['pdir_sf_fb_news_last_import_time'],
             'exclude' => true,
             'inputType' => 'text',
-            'sql' => "varchar(255) NOT NULL default ''",
+            'sql' => "varchar(255) NOT NULL default 0",
             'eval' => array('rgxp' => 'time', 'tl_class' => 'w50')
         ],
     ],


### PR DESCRIPTION
Having an empty string as the default value for a timestamp field causes an exception:

![image](https://user-images.githubusercontent.com/6792578/50160361-68262580-02d9-11e9-9289-540dacd7c5b4.png)

I set the default value to 0 to avoid this behavior.