### PR TITLE
Fix install with empty database

### DIFF
--- a/src/Resources/contao/config/runonce.php
+++ b/src/Resources/contao/config/runonce.php
@@ -8,14 +8,16 @@ class SocialFeedRunonce extends \Controller
     }
     public function run()
     {
-        if ($this->Database->fieldExists('pdir_sf_fb_id', 'tl_news')) {
-            $this->Database->query("ALTER TABLE tl_news CHANGE pdir_sf_fb_id social_feed_id VARCHAR(128) DEFAULT '' NOT NULL");
-        }
-        if ($this->Database->fieldExists('pdir_sf_fb_account', 'tl_news')) {
-            $this->Database->query("ALTER TABLE tl_news CHANGE pdir_sf_fb_account social_feed_account VARCHAR(128) DEFAULT '' NOT NULL");
-        }
-        if ($this->Database->fieldExists('pdir_sf_fb_account_picture', 'tl_news')) {
-            $this->Database->query("ALTER TABLE tl_news CHANGE pdir_sf_fb_account_picture social_feed_account_picture BINARY(16) DEFAULT NULL");
+        if ($this->Database->tableExists('tl_news')) {
+            if ($this->Database->fieldExists('pdir_sf_fb_id', 'tl_news')) {
+                $this->Database->query("ALTER TABLE tl_news CHANGE pdir_sf_fb_id social_feed_id VARCHAR(128) DEFAULT '' NOT NULL");
+            }
+            if ($this->Database->fieldExists('pdir_sf_fb_account', 'tl_news')) {
+                $this->Database->query("ALTER TABLE tl_news CHANGE pdir_sf_fb_account social_feed_account VARCHAR(128) DEFAULT '' NOT NULL");
+            }
+            if ($this->Database->fieldExists('pdir_sf_fb_account_picture', 'tl_news')) {
+                $this->Database->query("ALTER TABLE tl_news CHANGE pdir_sf_fb_account_picture social_feed_account_picture BINARY(16) DEFAULT NULL");
+            }
         }
     }
 }

--- a/src/Resources/contao/dca/tl_social_feed.php
+++ b/src/Resources/contao/dca/tl_social_feed.php
@@ -225,7 +225,10 @@ $GLOBALS['TL_DCA']['tl_social_feed'] = [
             'label' => &$GLOBALS['TL_LANG']['tl_news']['instagram_account_picture_size'],
             'exclude' => true,
             'inputType'  => 'imageSize',
-            'options' => \Contao\System::getImageSizes(),
+            'options_callback' => static function ()
+            {
+                return \Contao\System::getContainer()->get('contao.image.image_sizes')->getAllOptions();
+            },
             'reference' => &$GLOBALS['TL_LANG']['MSC'],
             'eval' => ['rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'],
             'sql' => "varchar(64) NOT NULL default ''"


### PR DESCRIPTION
If you have an empty database and run the installer you will get two errors:
1. `tl_news` is missing for runonce
2. `tl_image_sizes` is missing for the image size options

This features fixes this two errors!