### PR TITLE
Use reference and do not load language file

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -9,7 +9,6 @@
  * @license http://www.gnu.org/licences/lgpl-3.0.html LGPL
  */
 
-\Contao\System::loadLanguageFile('tl_module');
 
 /**
  * Add palette to tl_module
@@ -48,12 +47,8 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['pdir_sf_columns'] = array
     'eval' => [
         'tl_class' => 'w50'
     ],
-    'options' => array(
-        'column1' => $GLOBALS['TL_LANG']['tl_module']['column1'],
-        'columns2' => $GLOBALS['TL_LANG']['tl_module']['columns2'],
-        'columns3' => $GLOBALS['TL_LANG']['tl_module']['columns3'],
-        'columns4' => $GLOBALS['TL_LANG']['tl_module']['columns4']
-    ),
+    'options' => array('column1', 'columns2', 'columns3', 'columns4'),
+    'reference' => &$GLOBALS['TL_LANG']['tl_module'],
     'sql' => "varchar(64) NOT NULL default 'columns3'",
 );
 


### PR DESCRIPTION
Loading the language file for the same DCA within the DCA can lead to problems. It is not really necessary in this case anyway, if you use references instead (and by references I mean `&`, not the `reference` DCA setting).