### PR TITLE
Use empty string, if getPostMessage() returns null

### DIFF
--- a/src/EventListener/CronListener.php
+++ b/src/EventListener/CronListener.php
@@ -111,7 +111,7 @@ class CronListener extends System
                     $this->savePostPictures($picturePath, $media);
 
                     // Write in Database
-                    $message = $this->getPostMessage($media['caption']);
+                    $message = $this->getPostMessage($media['caption']) ?? '';
 
                     // add/fetch file from DBAFS
                     $objFile = Dbafs::addResource($imgPath.$media['id'].'.jpg');


### PR DESCRIPTION
Contao 4.9.42
SocialFeedBundle: 2.12.4

It only breaks on cron job execution.

I fixed it the same way it is in the `NewsImporter`:
https://github.com/pdir/social-feed-bundle/blob/a1c71f33c1a44105f251cd769971a3f6cc736ee9/src/Importer/NewsImporter.php#L83