### PR TITLE
Catch runtime exception on invalid images

### DIFF
--- a/src/SocialFeed/SocialFeedNewsClass.php
+++ b/src/SocialFeed/SocialFeedNewsClass.php
@@ -23,6 +23,7 @@ namespace Pdir\SocialFeedBundle\SocialFeed;
 use Contao\FilesModel;
 use Contao\StringUtil;
 use Contao\System;
+use Imagine\Exception\RuntimeException;
 use Pdir\SocialFeedBundle\Model\SocialFeedModel;
 
 class SocialFeedNewsClass
@@ -66,7 +67,11 @@ class SocialFeedNewsClass
                 }
 
                 if (null !== $imagePath) {
-                    $pictureObj = $pictureFactory->create($this->projectDir.DIRECTORY_SEPARATOR.$imagePath);
+                    try {
+                        $pictureObj = $pictureFactory->create($this->projectDir.DIRECTORY_SEPARATOR.$imagePath);
+                    } catch (RuntimeException) {
+                        $pictureObj = null;
+                    }
 
                     if (null !== $pictureObj) {
                         $objTemplate->accountPicture = $this->getTemplateData($pictureObj);


### PR DESCRIPTION
This PR fix a runtime exception when a broken image is loaded.

Background: In our current project the facebook api sometimes returns an image of 0 byte. When the social feed is show in the frontend, the complete page is broken due an Runtime Exception. This PR catch the exception, so the page still works even when there is a broken image.

Maybe we will further investigate why the api is returning a broken image and add an additional fix, but for now this fix the issue.

Tested on contao 5.3 and php 8.3. 
Based on current main branch.